### PR TITLE
Updating reference to Serbian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ contribute.
 * [Nederlands](https://github.com/necolas/idiomatic-css/tree/master/translations/nl-NL)
 * [Português (Brasil)](https://github.com/necolas/idiomatic-css/tree/master/translations/pt-BR)
 * [Русский](https://github.com/necolas/idiomatic-css/tree/master/translations/ru-RU)
-* [Srpski](https://github.com/necolas/idiomatic-css/tree/master/translations/sr)
+* [Srpski](https://github.com/necolas/idiomatic-css/tree/master/translations/sr-SR)
 * [Türkçe](https://github.com/necolas/idiomatic-css/tree/master/translations/tr-TR)
 * [简体中文](https://github.com/necolas/idiomatic-css/tree/master/translations/zh-CN)
 


### PR DESCRIPTION
In 7906004b5ca9471d77d5577f7b9fa93878b06eeb you renamed directory for Serbian translation, but the reference remand the same - here is small fix... :)
